### PR TITLE
諸々の微修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,7 @@
-# Nuxt 3 Minimal Starter
+# Mayu Teramoto's Portfolio
 
-Look at the [nuxt 3 documentation](https://v3.nuxtjs.org) to learn more.
+## Links
 
-## Setup
-
-Make sure to install the dependencies:
-
-```bash
-# yarn
-yarn install
-
-# npm
-npm install
-
-# pnpm
-pnpm install --shamefully-hoist
-```
-
-## Development Server
-
-Start the development server on http://localhost:3000
-
-```bash
-npm run dev
-```
-
-## Production
-
-Build the application for production:
-
-```bash
-npm run build
-```
-
-Locally preview production build:
-
-```bash
-npm run preview
-```
-
-Checkout the [deployment documentation](https://v3.nuxtjs.org/docs/deployment) for more information.
+- [GitHub Pages](https://ke3en.github.io/omayu_portfolio/)
+- [Netlify](https://app.netlify.com/sites/omayu-portfolio/overview)
+- [Adobe XD](https://xd.adobe.com/view/024d7cca-e254-4836-b43a-d300b5a1e919-571e/specs/)

--- a/components/molecules/MouseStalker.vue
+++ b/components/molecules/MouseStalker.vue
@@ -1,14 +1,13 @@
 <template>
-  <div id="mouse-stalker" :class="{'disable-mix-blend-mode': mouseStalkerText}">
+  <div id="mouse-stalker" :class="{ 'disable-mix-blend-mode': mouseStalkerText }">
     <div
-        :class="{'mouse-stalker--clickable': mouseStalkerText, 'mouse-stalker--clickable--dark': mouseStalkerText && (dark || isMouseStalkerTextDark)}"
-        class="mouse-stalker"
-    >
+      :class="{ 'mouse-stalker--clickable': mouseStalkerText, 'mouse-stalker--clickable--dark': mouseStalkerText && (dark || isMouseStalkerTextDark) }"
+      class="mouse-stalker">
       <span>
         {{ mouseStalkerTextToShow }}
       </span>
     </div>
-    <div :class="{'mouse-stalker__dot--clickable': mouseStalkerText}" class="mouse-stalker__dot"/>
+    <div :class="{ 'mouse-stalker__dot--clickable': mouseStalkerText }" class="mouse-stalker__dot" />
   </div>
 </template>
 
@@ -19,22 +18,27 @@ export default {
 </script>
 
 <script setup>
-import {onMounted} from "vue";
-import {useState} from "nuxt/app";
+import { onMounted } from "vue";
+import { useState } from "nuxt/app";
 
 const dark = useState('dark', () => false)
 const mouseStalkerText = useState('mouseStalkerText', () => '')
-const mouseStalkerTextToShow = computed(() => {
+const mouseStalkerTextToShow = computed(() =>
+{
   return mouseStalkerText.value.replace(/--dark/g, '')
 })
-const isMouseStalkerTextDark = computed(() => {
+const isMouseStalkerTextDark = computed(() =>
+{
   return mouseStalkerText.value.endsWith('--dark')
 })
 
-onMounted(() => {
-  if (process.client) {
+onMounted(() =>
+{
+  if (process.client)
+  {
     const stalker = window.document.getElementById('mouse-stalker')
-    window.document.addEventListener('mousemove', function (e) {
+    window.document.addEventListener('mousemove', function (e)
+    {
       stalker.style.transform = 'translate(' + e.clientX + 'px, ' + e.clientY + 'px)'
     })
   }
@@ -64,6 +68,7 @@ onMounted(() => {
   top: 30px;
   left: 30px;
   position: absolute;
+  transition: all 0.3s;
 }
 
 .mouse-stalker--clickable {
@@ -74,7 +79,6 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.3s;
   top: 0;
   left: 0;
   border-color: #000;
@@ -108,5 +112,4 @@ onMounted(() => {
 .mouse-stalker--clickable--dark span {
   color: #000;
 }
-
 </style>

--- a/components/molecules/ScrollToTopButton.vue
+++ b/components/molecules/ScrollToTopButton.vue
@@ -9,7 +9,7 @@ const backToTopImg: string = back_to_top
 const smoother = useState<ScrollSmoother>('smoother')
 const scrollTo = (target: string): void =>
 {
-    smoother.value.scrollTo(target, true);
+    smoother.value.scrollTo(target, false);
 }
 </script>
 

--- a/components/organisms/BannersView.vue
+++ b/components/organisms/BannersView.vue
@@ -6,31 +6,43 @@
       <div class="banners__horizontal-line" :style="horizontalLine1Style" />
       <div class="banners__horizontal-line" :style="horizontalLine2Style" />
       <div class="banners__title-container">
-        <img src="~/assets/image/textimg/top/Banner.svg?url" class="banners__title js-is-in-view-target" alt="Banner" />
+        <img :src="titleImg" class="banners__title js-is-in-view-target" alt="Banner" />
       </div>
-      <div v-for="(row, rowIndex) in chunkedItems" class="banners__row" :key="'row-' + rowIndex">
+      <div v-for="(row, rowIndex) in chunkedItemsToShow" class="banners__row" :key="'row-' + rowIndex">
         <img v-for="(item, itemIndex) in row" :alt="item.alt" :src="item.image"
           class="banners__item js-is-in-view-target clickable" :key="'item-' + rowIndex + '-' + itemIndex" />
       </div>
     </div>
-    <button class="clickable" :class="{ 'text--dark': dark }" type="button" style="cursor: none;">
-      View All
+    <button class="clickable" :class="{ 'text--dark': dark }" type="button" style="cursor: none;" @click="toggle">
+      <span v-if="isExpand">Hide</span>
+      <span v-else>View All</span>
     </button>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
-import { useResize } from '@/composables/useResize';
-
 import { chunk } from "lodash";
-import items from "assets/data/bannerItems.js";
+
+import titleImg from '@/assets/image/textimg/top/Banner.svg?url';
+import items from "@/assets/data/bannerItems.js";
+
 
 const dark = useState('dark', () => false)
 const containerHeightPx = ref(0)
 const titleContainerHeightPx = ref(0)
+const isExpand = ref(false)
 
-const chunkedItems = chunk(items.slice(0, 9), 3);
+const chunkedItems = chunk(items, 3);
+
+const chunkedItemsToShow = computed(() =>
+{
+  return isExpand.value ? chunkedItems : chunkedItems.slice(0, 3)
+})
+
+const toggle = () =>
+{
+  // isExpand.value = !isExpand.value
+}
 
 const updateContainerHeight = () =>
 {

--- a/components/organisms/FirstView.vue
+++ b/components/organisms/FirstView.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="first-view" class="first-view__container">
-    <MayuTeramoto />
+    <img :src="MayuTeramotoImg" alt="Mayu Teramoto" class="first-view__name" />
     <div class="first-view__scrolling-hint-container">
       <ScrollingHint />
     </div>
@@ -8,7 +8,7 @@
 </template>
 
 <script setup lang="ts">
-import MayuTeramoto from '@/assets/image/mayu_teramoto.svg';
+import MayuTeramotoImg from '@/assets/image/mayu_teramoto.svg?url';
 import ScrollingHint from '@/components/molecules/ScrollingHint.vue';
 </script>
 
@@ -22,6 +22,10 @@ import ScrollingHint from '@/components/molecules/ScrollingHint.vue';
     align-items: center;
     justify-content: center;
     margin-bottom: 58px;
+  }
+
+  &__name {
+    width: 100%;
   }
 
   &__scrolling-hint-container {

--- a/components/organisms/FirstView.vue
+++ b/components/organisms/FirstView.vue
@@ -21,7 +21,6 @@ import ScrollingHint from '@/components/molecules/ScrollingHint.vue';
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 58px;
   }
 
   &__name {

--- a/components/organisms/FooterView.vue
+++ b/components/organisms/FooterView.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="footer">
-    <img src="~/assets/image/textimg/top/thank_you_for_visiting.svg?url" alt="Thank you for visiting"
-      class="footer__ty" />
+    <img :src="ThankYouForVisitingImg" alt="Thank you for visiting" class="footer__ty" />
     <div class="footer__menu">
       <scroll-to-top-button />
       <p class="text-link"><a @click="scrollTo('#web-page')">Web Site</a></p>
@@ -15,6 +14,7 @@
 </template>
 
 <script setup lang="ts">
+import ThankYouForVisitingImg from '@/assets/image/textimg/top/thank_you_for_visiting.svg?url'
 import ScrollToTopButton from '@/components/molecules/ScrollToTopButton.vue';
 const smoother = useState<ScrollSmoother>('smoother')
 const scrollTo = (target: string): void =>
@@ -37,7 +37,8 @@ const year: number = new Date().getFullYear();
     align-items: center;
 
     .text-link {
-      margin-right: 26px;
+      margin-right: 25px;
+      font: normal normal normal 16px/24px ZenKakuGothicNew;
     }
   }
 

--- a/components/organisms/Profile.vue
+++ b/components/organisms/Profile.vue
@@ -30,7 +30,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0 60px 30px 60px;
+    padding: 100px 150px 130px 150px;
 
     div {
       width: auto;

--- a/components/organisms/Profile.vue
+++ b/components/organisms/Profile.vue
@@ -10,7 +10,7 @@
         <a class="text-link" href="https://twitter.com/myttt33" rel="noopener" target="_blank">
           <img src="~/assets/image/profile/icon_twitter.svg?url" />
         </a>
-        <a class="text-link" href="https://www.instagram.com/asage.mmeog/" rel="noopener" target="_blank">
+        <a class="text-link" href="https://www.instagram.com/asage_ttt/" rel="noopener" target="_blank">
           <img src="~/assets/image/profile/icon_instagram.svg?url" />
         </a>
       </div>

--- a/components/organisms/ProfileModal.vue
+++ b/components/organisms/ProfileModal.vue
@@ -1,20 +1,14 @@
 <template>
   <nav :class="{ 'profile-modal--open': showModal }" class="profile-modal">
     <div class="profile-modal__contents">
-      <ul class="profile-modal__nav-menu">
-        <li>
-          <img src="~/assets/image/textimg/hb/web_site.svg?url" class="js-is-in-view-target" alt="Web Site"
-            @click="hideModalAndScrollTo('#web-page')" />
-        </li>
-        <li>
-          <img src="~/assets/image/textimg/hb/Banner.svg?url" class="js-is-in-view-target" alt="Banner"
-            @click="hideModalAndScrollTo('#banner')" />
-        </li>
-        <li>
-          <img src="~/assets/image/textimg/hb/Illustration.svg?url" class="js-is-in-view-target" alt="Illustration"
-            @click="hideModalAndScrollTo('#illustration')" />
-        </li>
-      </ul>
+      <div class="profile-modal__nav-menu">
+        <img :src="WebSiteImg" class="profile-modal__nav-menu-item js-is-in-view-target" alt="Web Site"
+          @click="hideModalAndScrollTo('#web-page')" />
+        <img :src="BannerImg" class="profile-modal__nav-menu-item js-is-in-view-target" alt="Banner"
+          @click="hideModalAndScrollTo('#banner')" />
+        <img :src="IllustrationImg" class="profile-modal__nav-menu-item js-is-in-view-target" alt="Illustration"
+          @click="hideModalAndScrollTo('#illustration')" />
+      </div>
       <hr>
       <profile />
     </div>
@@ -22,6 +16,9 @@
 </template>
 
 <script setup lang="ts">
+import WebSiteImg from '@/assets/image/textimg/hb/web_site.svg?url';
+import BannerImg from '@/assets/image/textimg/hb/Banner.svg?url';
+import IllustrationImg from '@/assets/image/textimg/hb/Illustration.svg?url';
 const showModal = useState('showModal', () => false)
 const dark = useState('dark', () => false)
 const smoother = useState<ScrollSmoother>('smoother')
@@ -64,10 +61,8 @@ const hideModalAndScrollTo = (target: string) =>
   }
 
   &__contents {
-    padding: 100px 90px;
-
     hr {
-      margin-bottom: 100px;
+      margin: 0;
       background-color: #3B3B3B;
       height: 0.5px;
       border: none;
@@ -75,22 +70,21 @@ const hideModalAndScrollTo = (target: string) =>
   }
 
   &__nav-menu {
-    margin-bottom: 50px;
+    padding: 100px 100px;
+    margin: 0;
 
-    li {
-      margin-bottom: 50px;
-      font-size: 170px;
-      line-height: 1em;
-      font-family: Valery, serif;
-      color: #5A5A5A;
-    }
-
-    li img {
+    &-item {
+      display: block;
       transition-duration: .5s;
-    }
 
-    li img:hover {
-      opacity: 0.4;
+      &:hover {
+        opacity: 0.4;
+      }
+
+      &:not(:last-child) {
+        margin-bottom: 50px;
+      }
+
     }
   }
 }

--- a/components/organisms/WebSitesView.vue
+++ b/components/organisms/WebSitesView.vue
@@ -20,18 +20,19 @@ $img-margin-y: 100px;
 
 .web-sites {
   &__container {
-    padding: 100px 100px 250px 100px;
+    padding: 100px 100px 220px 100px;
     text-align: center;
   }
 
   &__title {
-    margin: 130px 0;
+    margin: 100px 0;
     text-align: center;
   }
 
   &__row {
     display: flex;
     justify-content: space-between;
+    margin: 30px 0;
   }
 
   &__row:nth-of-type(1) img:nth-of-type(1) {


### PR DESCRIPTION
## 今回の修正には含めないこと
- Illustrationの実装
- Bannerの「View All」ボタンを押した際の挙動の実装
- 1365px x 768px 以外の画面サイズでのレイアウト調整

## 今回の修正内容

### マウスカーソルのアニメーション修正
- これまで：カーソルがクリック可能要素内から要素外に移動した際に、カーソルのサイズがアニメーション無しで縮小していた。
- これから：カーソルのサイズ縮小時にスムーズにサイズが変わるようにした。

### 「上へ戻るボタン」のスクロールアニメーション無効化
- これまで：フッターの「上へ戻るボタン」を押した際に、擬似的に上方向のスクロールをしているような挙動になっていた。
- これから：ボタンを押したと同時にページトップに切り替わるような挙動にした。

### ファーストビューのサイズ上限廃止
- これまで：画像サイズが表示サイズの上限となっていた。
- これから：画面サイズの横幅いっぱいまで広げるようにした。

### その他の微修正
- マージン調整（Illustrationのみ未調整）
- Instagramの外部リンクURL
